### PR TITLE
StorageType to handle cpu and cuda tensor

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -7,7 +7,6 @@ use ndarray::prelude::*;
 use tensor::tensor::Tensor;
 use crate::nn::layers::{Layer, Linear, MeanSquaredError, ReLU, Sigmoid};
 use crate::nn::model::NN;
-use crate::operators::operators::shared_ptr_new;
 
 fn main() {
     struct MyModel {layer1: Linear, sig: Sigmoid, layer2: Linear }

--- a/examples/fit_sine.rs
+++ b/examples/fit_sine.rs
@@ -93,7 +93,7 @@ fn main() {
     }
     let linear_layer = &model.parameters()[..];
     if let [w, bias] = linear_layer {
-        let v = &w.data().clone().into_raw_vec()[..];
+        let v = &w.data().into_raw_vec()[..];
         if let [b, c, d] = v {
             let a_bias = bias.data()[[0, 0]];
             println!("Result: y = {a_bias} + {b} x + {c} x^2 + {d} x^3");

--- a/src/autograd/autograd.rs
+++ b/src/autograd/autograd.rs
@@ -1,5 +1,6 @@
 use crate::operators::operators::{Operator, Operators};
-use crate::tensor::tensor::{Powi, Primitive, Tensor};
+use crate::tensor::Primitive;
+use crate::tensor::tensor::{Powi, Tensor};
 use ndarray::linalg::Dot;
 use ndarray::{Array, Dimension, Ix2};
 use num_traits::{Float, FromPrimitive};

--- a/src/nn/layers.rs
+++ b/src/nn/layers.rs
@@ -1,6 +1,13 @@
+/**
+ * Layers are just high-level abstractions for operators: you can have layers with multiple operators (ie transformerblock)
+ * hence they really represent a subgraph of the whole network computation graph.
+ * By default the forward of the layer is just a sequential application of the operators in the subgraph, but
+ * it can be easily overriden to implement more complex logic.
+*/
 use crate::operators;
 use crate::tensor::init::calculate_fan_in_and_fan_out;
-use crate::tensor::tensor::{Powi, Primitive};
+use crate::tensor::Primitive;
+use crate::tensor::tensor::Powi;
 use crate::{
     operators::operators::{Operator, Operators},
     tensor::tensor::Tensor,

--- a/src/nn/model.rs
+++ b/src/nn/model.rs
@@ -1,5 +1,6 @@
 use num_traits::{Float, FromPrimitive};
-use crate::tensor::tensor::{Powi, Primitive, Tensor};
+use crate::tensor::Primitive;
+use crate::tensor::tensor::{Powi, Tensor};
 use super::layers::Layer;
 
 // you have to define the forward on your own

--- a/src/operators/functional_ndarray.rs
+++ b/src/operators/functional_ndarray.rs
@@ -1,0 +1,136 @@
+use std::vec;
+
+// Implementation of operators (ReLU, Linear..) which make use of the ndarray interface
+// directly; this is to avoid having a joint interface on StorageType for cuda
+// and ndarray for operations that wouldn't make sense on cuda (ie slow iters).
+use ndarray::linalg::Dot;
+use ndarray::s;
+use ndarray::{Array, ArrayD, Ix2, IxDyn};
+
+use crate::tensor::tensor::Primitive;
+
+pub fn relu_ndarray<T: Primitive>(x: &ArrayD<T>) -> ArrayD<T> {
+    let mut t = ArrayD::<T>::zeros(x.raw_dim());
+    for (tv, xv) in t.iter_mut().zip(x.iter()) {
+        if *xv > T::from(0).unwrap() {
+            *tv = *xv;
+        }
+    }
+    t
+}
+pub fn relu_backward_ndarray(xs: Vec<&ArrayD<f32>>, grad: &mut ArrayD<f32>) -> Vec<ArrayD<f32>> {
+    let x = xs[0];
+    // re-use grad storage: avoid optimization for now
+    // for (g_i, x_i) in grad.iter_mut().zip(x.iter()) {
+    let mut g = grad.clone();
+    for (g_i, x_i) in g.iter_mut().zip(x.iter()) {
+        if *x_i <= 0.0 {
+            *g_i = 0.0;
+        }
+    }
+    vec![g]
+}
+
+
+/**
+ * See operators.Conv2d.im2col.
+ */
+pub fn im2col_ndarray<T: Primitive>(
+    im: &ArrayD<T>,
+    k_size: usize,
+    stride: usize,
+    pad: usize,
+) -> Result<ArrayD<T>, String> {
+    // single ksize for both x/y direction for now
+    if let [b, c, h, w] = im.shape()[..] {
+        // number of conv operations/slides on both axis
+        let new_height = (h - k_size + 2 * pad) / stride + 1;
+        let new_width = (w - k_size + 2 * pad) / stride + 1;
+        // #conv_ops X kernel_size*C, ie each conv is unfolded (channel-wise too)
+        let mut col =
+            ArrayD::<T>::zeros(IxDyn(&[b, new_height * new_width, c * k_size * k_size]));
+
+        // since reshaping (below) requires a contiguous array, we re-use the same memory location so we save allocation
+        // also, handling lateral im-filter overlaps when padding is tricky
+        let mut patch_buffer = ArrayD::<T>::zeros(IxDyn(&[b, c * k_size * k_size]));
+        let k_size = k_size as i32; // could overflow below!
+        let pad = pad as i32;
+        // go over each kernel slide (nh*nw="#convolutions") NOT over "col" pixels
+        for y in 0..new_height {
+            // NOTE we don't actually pad the input as it can be very expensive; we can recognize when patch
+            // is out of bound (due to padding, wrt im origin) and only copy the sub-slice we need
+            let patch_y = (y * stride) as i32 - pad;
+            for x in 0..new_width {
+                // lay out patch as a column vector
+                let patch_x = (x * stride) as i32 - pad;
+                // how you would do it if there was no padding, select patch and flatten
+                // let patch_idxs = s![.., .., patch_y..patch_y+k_size, patch_x..patch_x+k_size];
+                // let patch = im.slice(patch_idxs).into_owned();
+                // let patch = patch.into_shape((b, patch.len() / b)).unwrap();
+                // ..in particular, we handle the tricky case ('|' im boundaries, '/'kernel boundaries)
+                // |X../X|0/
+                // |X../X|0/   where X-0-X-0 slice needs to be flattened in this order
+
+                let mut counter = 0;
+                for ch in 0..c {
+                    for i in patch_y..(patch_y + k_size) {
+                        for j in patch_x..(patch_x + k_size) {
+                            if i >= 0 && i < h as i32 && j >= 0 && j < w as i32 {
+                                patch_buffer.slice_mut(s![.., counter]).assign(&im.slice(s![
+                                    ..,
+                                    ch,
+                                    i,
+                                    j
+                                ]));
+                            }
+                            counter += 1;
+                        }
+                    }
+                }
+                // this assigns a whole row of "col" (data locality happy), indexing from patch y/x coordinates
+                col.slice_mut(s![.., y * new_width + x, ..])
+                    .assign(&patch_buffer);
+                patch_buffer.fill(T::zero());
+            }
+        }
+        return Ok(col);
+    }
+    Err(format!(
+        "Expected image of shape BCHW, got shape {:?}",
+        im.shape()
+    ))
+}
+
+
+pub fn im2col_ndarray_backward<T: Primitive>(
+    col: &ArrayD<T>,
+    h_out: usize,
+    w_out: usize,
+    stride: usize,
+    k_size: usize,
+) -> Result<ArrayD<T>, String> {
+    if let [b, P, K] = col.shape()[..] {
+        // original image sizes
+        let c = K / (k_size * k_size);
+        let h = (h_out - 1) * stride + k_size;
+        let w = (w_out - 1) * stride + k_size;
+        let mut im = ArrayD::<T>::zeros(IxDyn(&[b, c, h, w]));
+        // go through each flattened patch, reshape it and sum contributions on overlapping patches
+        for i in 0..P {
+            // BxK*K*C
+            let row = col.slice(s![.., i, ..]);
+            let y = (i / w_out) * stride;
+            let x = (i % w_out) * stride;
+            let mut patch = im.slice_mut(s![.., .., y..y + k_size, x..x + k_size]);
+            // patch += &row; needs extra signature..
+            // we can reshape without owning view as the slice is contiguous
+            let p = &patch + &row.into_shape((b, c, k_size, k_size)).unwrap();
+            patch.assign(&p);
+        }
+        return Ok(im);
+    }
+    Err(format!(
+        "Expected tensor of shape BxH_out*W_outxK*K*C, got shape {:?}",
+        col.shape()
+    ))
+}

--- a/src/operators/functional_ndarray.rs
+++ b/src/operators/functional_ndarray.rs
@@ -6,8 +6,10 @@ use std::vec;
 use ndarray::linalg::Dot;
 use ndarray::s;
 use ndarray::{Array, ArrayD, Ix2, IxDyn};
+use crate::tensor::Primitive;
 
-use crate::tensor::tensor::Primitive;
+// NOTE if there's some function you dont want to implement in cuda(ie broadcast)
+// just move its implementation here and avoid common interface
 
 pub fn relu_ndarray<T: Primitive>(x: &ArrayD<T>) -> ArrayD<T> {
     let mut t = ArrayD::<T>::zeros(x.raw_dim());

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -1,1 +1,2 @@
 pub mod operators;
+mod functional_ndarray;

--- a/src/operators/operators.rs
+++ b/src/operators/operators.rs
@@ -1,24 +1,19 @@
 use ndarray::linalg::Dot;
 use ndarray::s;
 use ndarray::{Array, ArrayD, Ix2, IxDyn};
-use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::autograd::autograd::Node;
 use crate::operators::functional_ndarray::{relu_backward_ndarray, relu_ndarray, im2col_ndarray};
 use crate::storage_apply;
-use crate::tensor::tensor::{
-    ones_like, ones_like_f32, zeros_like, CudaData, Powi, Primitive, StorageType, Tensor,
-};
+use crate::tensor::Primitive;
+use crate::tensor::storage::{StorageType, CudaData};
+use crate::tensor::tensor::{ones_like, ones_like_f32, zeros_like, Powi, Tensor};
 
 use super::functional_ndarray::im2col_ndarray_backward;
+use crate::utils::{SharedPtr, shared_ptr_new};
 
-type SharedPtr<T> = Rc<RefCell<T>>;
 
-// TODO to utils
-pub fn shared_ptr_new<T>(x: T) -> SharedPtr<T> {
-    Rc::new(RefCell::new(x))
-}
 
 pub trait Operator {
     fn forward<T: Primitive + 'static>(&self, xs: Vec<Tensor<T>>) -> Tensor<T>

--- a/src/tensor/arithmetic.rs
+++ b/src/tensor/arithmetic.rs
@@ -280,7 +280,7 @@ where
 {
     type Output = Tensor<T>;
     fn div(self, rhs: T) -> Self::Output {
-        Tensor::from(self.data().to_owned() / rhs)
+        Tensor::from(&*self.data() / rhs)
     }
 }
 
@@ -290,7 +290,7 @@ where
 {
     type Output = Tensor<T>;
     fn div(self, rhs: T) -> Self::Output {
-        Tensor::from(self.data().to_owned() / rhs)
+        Tensor::from(&*self.data() / rhs)
     }
 }
 
@@ -308,26 +308,14 @@ where
 impl Sub<Tensor<f32>> for f32 {
     type Output = Tensor<f32>;
     fn sub(self, rhs: Tensor<f32>) -> Self::Output {
-        let b = &*rhs.data();
-        if let StorageType::ArrayData(arr) = b {
-            let scalar_arr = ndarray::array![self].into_dyn();
-            Tensor::from(scalar_arr - arr)
-        } else {
-            todo!()
-        }
+        Tensor::from(self - &*rhs.data())
     }
 }
 
 impl Sub<&Tensor<f32>> for f32 {
     type Output = Tensor<f32>;
     fn sub(self, rhs: &Tensor<f32>) -> Self::Output {
-        let b = &*rhs.data();
-        if let StorageType::ArrayData(arr) = b {
-            let scalar_arr = ndarray::array![self].into_dyn();
-            Tensor::from(scalar_arr - arr)
-        } else {
-            todo!()
-        }
+        Tensor::from(self - &*rhs.data())
     }
 }
 // FIXME remove T: Float trait to implement this and properly support ints

--- a/src/tensor/arithmetic.rs
+++ b/src/tensor/arithmetic.rs
@@ -151,15 +151,6 @@ where
     }
 }
 
-impl<T> Sub<Tensor<T>> for Tensor<T>
-where
-    T: Primitive,
-{
-    type Output = Tensor<T>;
-    fn sub(self, rhs: Tensor<T>) -> Self::Output {
-        self - &rhs
-    }
-}
 
 impl<T> Sub<&Tensor<T>> for &Tensor<T>
 where
@@ -173,15 +164,40 @@ where
     }
 }
 
-impl<T> SubAssign<&Tensor<T>> for &Tensor<T>
+impl<T> Sub<Tensor<T>> for Tensor<T>
 where
     T: Primitive,
+{
+    type Output = Tensor<T>;
+    fn sub(self, rhs: Tensor<T>) -> Self::Output {
+        self - &rhs
+    }
+}
+
+
+// TODO not sure if needed
+// &A -= &B
+// impl<T> SubAssign<&Tensor<T>> for &mut Tensor<T>
+// where
+//     T: Primitive,
+//     ArrayD<T>: for<'a> SubAssign<&'a ArrayD<T>>,
+// {
+//     fn sub_assign(&mut self, rhs: &Tensor<T>) {
+//         let mut a = &mut *self.data_mut();
+//         let b = &*rhs.data();
+//         a -= b;
+//     }
+// }
+
+// A -= &B
+impl<T> SubAssign<&Tensor<T>> for Tensor<T>
+where
+    T: Primitive,
+    // ArrayD<T>: SubAssign<ArrayD<T>>
     ArrayD<T>: for<'a> SubAssign<&'a ArrayD<T>>,
 {
     fn sub_assign(&mut self, rhs: &Tensor<T>) {
-        let mut a = self.data_mut();
-        let b = &*rhs.data();
-        *a -= b;
+        tensor_op_mut(self, &rhs, |a, b| *a -= b);
     }
 }
 

--- a/src/tensor/arithmetic.rs
+++ b/src/tensor/arithmetic.rs
@@ -238,11 +238,8 @@ where
     T: Primitive,
 {
     type Output = Tensor<T>;
-    fn mul(mut self, rhs: Tensor<T>) -> Self::Output {
-        tensor_op_mut(&mut self, &rhs, |a, b| {
-            a.zip_mut_with(b, move |y, &x| *y = *y * x)
-        });
-        self
+    fn mul(self, rhs: Tensor<T>) -> Self::Output {
+        self * &rhs 
     }
 }
 

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -1,3 +1,4 @@
 pub mod tensor;
 mod arithmetic;
+mod storage;
 pub mod init;

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -2,3 +2,4 @@ pub mod tensor;
 mod arithmetic;
 mod storage;
 pub mod init;
+mod utils;

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -1,5 +1,14 @@
 pub mod tensor;
-mod arithmetic;
-mod storage;
+pub mod storage;
+mod tensor_arithmetic;
+mod storage_arithmetic;
 pub mod init;
 mod utils;
+
+use num_traits::{cast::FromPrimitive, Num, NumCast};
+pub trait Primitive: Copy + NumCast + Num + PartialOrd<Self> + Clone + FromPrimitive {}
+impl Primitive for u8 {}
+impl Primitive for f32 {}
+impl Primitive for f64 {}
+impl Primitive for i32 {}
+impl Primitive for i64 {}

--- a/src/tensor/storage.rs
+++ b/src/tensor/storage.rs
@@ -1,0 +1,276 @@
+use super::tensor::{Primitive, StorageType, CudaData};
+use ndarray::{ArrayD, IxDyn, ScalarOperand};
+use num_traits::Signed;
+use std::ops::{self, Not};
+use std::ops::{AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+// Tensor + Tensor => StorageType + StorageType  => Array + Array
+//                                              \=> CudaData + CudaData
+
+/**
+* Arithmetic rules ndarray
+*
+   &A @ &A which produces a new Array
+   B @ A which consumes B, updates it with the result, and returns it
+   B @ &A which consumes B, updates it with the result, and returns it
+   C @= &A which performs an arithmetic operation in place
+
+    use ndarray::{array, ArrayView1};
+
+    let owned1 = array![1, 2];
+    let owned2 = array![3, 4];
+    let view1 = ArrayView1::from(&[5, 6]);
+    let view2 = ArrayView1::from(&[7, 8]);
+    let mut mutable = array![9, 10];
+
+    let sum1 = &view1 + &view2;   // Allocates a new array. Note the explicit `&`.
+    // let sum2 = view1 + &view2; // This doesn't work because `view1` is not an owned array.
+    let sum3 = owned1 + view1;    // Consumes `owned1` (moves it, need to re-assign it), updates it, and returns it.
+    let sum4 = owned2 + &view2;   // Consumes `owned2`, updates it, and returns it.
+    mutable += &view2;            // Updates `mutable` in-place.
+ */
+
+// &A + &B
+impl<T> ops::Add<&StorageType<T>> for &StorageType<T>
+where
+    T: Primitive,
+{
+    type Output = StorageType<T>;
+
+    fn add(self, rhs: &StorageType<T>) -> Self::Output {
+      todo!()
+    }
+}
+
+// A + B
+impl<T> ops::Add<StorageType<T>> for StorageType<T>
+where
+    T: Primitive,
+{
+    type Output = StorageType<T>;
+    fn add(mut self, rhs: StorageType<T>) -> StorageType<T> {
+      todo!()
+    }
+}
+
+// A += &B
+impl<T> AddAssign<&StorageType<T>> for StorageType<T>
+where
+    T: Primitive,
+    ArrayD<T>: for<'a> AddAssign<&'a ArrayD<T>>,
+{
+    fn add_assign(&mut self, rhs: &StorageType<T>) {
+       todo!()
+    }
+}
+
+// A + &B, add(&B) for A
+impl<T> ops::Add<&StorageType<T>> for StorageType<T>
+where
+    T: Primitive,
+{
+    type Output = StorageType<T>;
+    fn add(mut self, rhs: &StorageType<T>) -> Self::Output {
+        todo!()
+    }
+}
+
+
+// Subtraction
+impl<T> Sub for &StorageType<T> {
+    type Output = StorageType<T>;
+
+    fn sub(self, other: Self) -> StorageType<T> {
+        todo!()
+    }
+}
+
+impl<T> Sub for StorageType<T> {
+    type Output = StorageType<T>;
+
+    fn sub(self, other: StorageType<T>) -> StorageType<T> {
+        todo!()
+    }
+}
+
+impl<T> Sub<&StorageType<T>> for StorageType<T> {
+    type Output = StorageType<T>;
+
+    fn sub(self, other: &StorageType<T>) -> StorageType<T> {
+        todo!()
+    }
+}
+
+impl<T>SubAssign<&StorageType<T>> for StorageType<T> {
+    fn sub_assign(&mut self, other: &StorageType<T>) {
+        todo!()
+    }
+}
+
+// Multiplication
+impl<T> Mul for &StorageType<T> {
+    type Output = StorageType<T>;
+
+    fn mul(self, other: Self) -> StorageType<T> {
+        todo!()
+    }
+}
+
+impl<T> Mul for StorageType<T> {
+    type Output = StorageType<T>;
+
+    fn mul(self, other: StorageType<T>) -> StorageType<T> {
+        todo!()
+    }
+}
+
+impl<T> Mul<&StorageType<T>> for StorageType<T> {
+    type Output = StorageType<T>;
+
+    fn mul(self, other: &StorageType<T>) -> StorageType<T> {
+        todo!()
+    }
+}
+
+impl<T> MulAssign<&StorageType<T>> for StorageType<T> {
+    fn mul_assign(&mut self, other: &StorageType<T>) {
+        todo!()
+    }
+}
+
+// Negation
+impl<T> Neg for StorageType<T> {
+    type Output = StorageType<T>;
+
+    fn neg(self) -> StorageType<T> {
+        todo!()
+    }
+}
+
+// Equality comparison
+impl<T> PartialEq for StorageType<T> {
+    fn eq(&self, other: &Self) -> bool {
+        todo!()
+    }
+}
+
+impl<T> Div<T> for StorageType<T>
+where
+    T: Primitive + ScalarOperand,
+{
+    type Output = StorageType<T>;
+    fn div(self, rhs: T) -> Self::Output {
+        todo!()
+    }
+}
+
+impl<T> Div<T> for &StorageType<T>
+where
+    T: Primitive + ScalarOperand,
+{
+    type Output = StorageType<T>;
+    fn div(self, rhs: T) -> Self::Output {
+        todo!()
+    }
+}
+
+impl<T> DivAssign<T> for StorageType<T>
+where
+    T: Primitive + ScalarOperand + DivAssign,
+{
+    fn div_assign(&mut self, rhs: T) {
+        todo!()
+    }
+}
+
+// Scalar - Tensor
+impl Sub<StorageType<f32>> for f32 {
+    type Output = StorageType<f32>;
+    fn sub(self, rhs: StorageType<f32>) -> Self::Output {
+        todo!()
+    }
+}
+
+impl Sub<&StorageType<f32>> for f32 {
+    type Output = StorageType<f32>;
+    fn sub(self, rhs: &StorageType<f32>) -> Self::Output {
+        todo!()
+    }
+}
+
+impl<T> Mul<T> for StorageType<T>
+where
+    T: Primitive + ScalarOperand,
+{
+    type Output = StorageType<T>;
+    fn mul(self, rhs: T) -> Self::Output {
+        todo!()
+    }
+}
+
+impl<T> Mul<T> for &StorageType<T>
+where
+    T: Primitive + ScalarOperand,
+{
+    type Output = StorageType<T>;
+    fn mul(self, rhs: T) -> Self::Output {
+        todo!()
+    }
+}
+
+impl<T> MulAssign<T> for StorageType<T>
+where
+    T: Primitive + ScalarOperand + MulAssign,
+{
+    fn mul_assign(&mut self, rhs: T) {
+       todo!()
+    }
+}
+
+
+
+/*************** CUDA ops ****************/
+// &A + &B
+impl<T> ops::Add<&CudaData<T>> for &CudaData<T>
+where
+    T: Primitive,
+{
+    type Output = CudaData<T>;
+
+    fn add(self, rhs: &CudaData<T>) -> Self::Output {
+      todo!()
+    }
+}
+
+// A + B
+impl<T> ops::Add<CudaData<T>> for CudaData<T>
+where
+    T: Primitive,
+{
+    type Output = CudaData<T>;
+    fn add(mut self, rhs: CudaData<T>) -> CudaData<T> {
+      todo!()
+    }
+}
+
+// A += &B
+impl<T> AddAssign<&CudaData<T>> for CudaData<T>
+where
+    T: Primitive,
+    ArrayD<T>: for<'a> AddAssign<&'a ArrayD<T>>,
+{
+    fn add_assign(&mut self, rhs: &CudaData<T>) {
+       todo!()
+    }
+}
+
+// A + &B, add(&B) for A
+impl<T> ops::Add<&CudaData<T>> for CudaData<T>
+where
+    T: Primitive,
+{
+    type Output = CudaData<T>;
+    fn add(mut self, rhs: &CudaData<T>) -> Self::Output {
+        todo!()
+    }
+}

--- a/src/tensor/storage.rs
+++ b/src/tensor/storage.rs
@@ -1,8 +1,9 @@
-use super::tensor::{Primitive, StorageType, CudaData};
+use super::tensor::{CudaData, Primitive, StorageType};
 use ndarray::{ArrayD, IxDyn, ScalarOperand};
 use num_traits::Signed;
 use std::ops::{self, Not};
 use std::ops::{AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use std::ops::{Index, IndexMut};
 
 // Tensor + Tensor => StorageType + StorageType  => Array + Array
 //                                              \=> CudaData + CudaData
@@ -38,7 +39,7 @@ where
     type Output = StorageType<T>;
 
     fn add(self, rhs: &StorageType<T>) -> Self::Output {
-      todo!()
+        todo!()
     }
 }
 
@@ -49,7 +50,7 @@ where
 {
     type Output = StorageType<T>;
     fn add(mut self, rhs: StorageType<T>) -> StorageType<T> {
-      todo!()
+        todo!()
     }
 }
 
@@ -60,7 +61,7 @@ where
     ArrayD<T>: for<'a> AddAssign<&'a ArrayD<T>>,
 {
     fn add_assign(&mut self, rhs: &StorageType<T>) {
-       todo!()
+        todo!()
     }
 }
 
@@ -74,7 +75,6 @@ where
         todo!()
     }
 }
-
 
 // Subtraction
 impl<T> Sub for &StorageType<T> {
@@ -101,7 +101,7 @@ impl<T> Sub<&StorageType<T>> for StorageType<T> {
     }
 }
 
-impl<T>SubAssign<&StorageType<T>> for StorageType<T> {
+impl<T> SubAssign<&StorageType<T>> for StorageType<T> {
     fn sub_assign(&mut self, other: &StorageType<T>) {
         todo!()
     }
@@ -223,11 +223,79 @@ where
     T: Primitive + ScalarOperand + MulAssign,
 {
     fn mul_assign(&mut self, rhs: T) {
-       todo!()
+        todo!()
     }
 }
 
 
+/** Indexing **/
+// impl<T> StorageType<T> {
+//     fn compute_flat_index(&self, index: &[usize]) -> usize {
+//         // Compute a flat index from the multi-dimensional index.
+//         // This usually involves multiplying the index components by the size of the corresponding dimensions.
+//         // Here, we assume row-major order for simplicity.
+//         let mut flat_index = 0;
+//         for (i, &dim_size) in self.dims.iter().enumerate() {
+//             flat_index = flat_index * dim_size + index[i];
+//         }
+//         flat_index
+//     }
+// }
+
+impl<T> Index<&[usize]> for StorageType<T> {
+    type Output = T;
+
+    fn index(&self, index: &[usize]) -> &Self::Output {
+        if let StorageType::ArrayData(arr) = &self {
+            return &arr[index];
+        } else {
+            todo!()
+        }
+    }
+}
+
+impl<T> IndexMut<&[usize]> for StorageType<T> {
+    fn index_mut(&mut self, index: &[usize]) -> &mut Self::Output {
+        if let StorageType::ArrayData(arr) = self {
+            return arr.index_mut(index);
+        } else {
+            todo!()
+        }
+    }
+}
+
+// index with fixed-size arrays
+macro_rules! add_indexing {
+    ($dims:expr) => {
+        impl<T:Primitive> Index<[usize; $dims]> for StorageType<T> {
+            type Output = T;
+
+            fn index(&self, index: [usize; $dims]) -> &Self::Output {
+                if let StorageType::ArrayData(arr) = &self {
+                    return &arr[index];
+                } else {
+                    todo!()
+                }
+            }
+        }
+
+        impl<T:Primitive> IndexMut<[usize; $dims]> for StorageType<T> {
+            fn index_mut(&mut self, index: [usize; $dims]) -> &mut Self::Output {
+                if let StorageType::ArrayData(arr) = self {
+                    return arr.index_mut(index);
+                } else {
+                    todo!()
+                }
+            }
+        }
+    };
+}
+
+add_indexing!(1);
+add_indexing!(2);
+add_indexing!(3);
+add_indexing!(4);
+add_indexing!(5);
 
 /*************** CUDA ops ****************/
 // &A + &B
@@ -238,7 +306,7 @@ where
     type Output = CudaData<T>;
 
     fn add(self, rhs: &CudaData<T>) -> Self::Output {
-      todo!()
+        todo!()
     }
 }
 
@@ -249,7 +317,7 @@ where
 {
     type Output = CudaData<T>;
     fn add(mut self, rhs: CudaData<T>) -> CudaData<T> {
-      todo!()
+        todo!()
     }
 }
 
@@ -260,7 +328,7 @@ where
     ArrayD<T>: for<'a> AddAssign<&'a ArrayD<T>>,
 {
     fn add_assign(&mut self, rhs: &CudaData<T>) {
-       todo!()
+        todo!()
     }
 }
 

--- a/src/tensor/storage_arithmetic.rs
+++ b/src/tensor/storage_arithmetic.rs
@@ -1,0 +1,467 @@
+use crate::{storage_apply, storage_apply2};
+
+use crate::tensor::Primitive;
+use super::storage::{CudaData, StorageType};
+use super::utils::{storage_binary_move_op, storage_binary_op, storage_binary_op_mut};
+use ndarray::{ArrayD, ScalarOperand};
+use std::ops::{self, Not};
+use std::ops::{AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use std::ops::{Index, IndexMut};
+
+// Tensor + Tensor => StorageType + StorageType  => Array + Array
+//                                              \=> CudaData + CudaData
+
+/**
+* Arithmetic rules ndarray
+*
+   &A @ &A which produces a new Array
+   B @ A which consumes B, updates it with the result, and returns it
+   B @ &A which consumes B, updates it with the result, and returns it
+   C @= &A which performs an arithmetic operation in place
+
+    use ndarray::{array, ArrayView1};
+
+    let owned1 = array![1, 2];
+    let owned2 = array![3, 4];
+    let view1 = ArrayView1::from(&[5, 6]);
+    let view2 = ArrayView1::from(&[7, 8]);
+    let mut mutable = array![9, 10];
+
+    let sum1 = &view1 + &view2;   // Allocates a new array. Note the explicit `&`.
+    // let sum2 = view1 + &view2; // This doesn't work because `view1` is not an owned array.
+    let sum3 = owned1 + view1;    // Consumes `owned1` (moves it, need to re-assign it), updates it, and returns it.
+    let sum4 = owned2 + &view2;   // Consumes `owned2`, updates it, and returns it.
+    mutable += &view2;            // Updates `mutable` in-place.
+ */
+
+// &A + &B
+impl<T: Primitive> ops::Add<&StorageType<T>> for &StorageType<T>
+where
+    T: Primitive,
+{
+    type Output = StorageType<T>;
+
+    fn add(self, rhs: &StorageType<T>) -> Self::Output {
+        todo!()
+    }
+}
+
+// A + B
+impl<T: Primitive> ops::Add<StorageType<T>> for StorageType<T>
+where
+    T: Primitive,
+{
+    type Output = StorageType<T>;
+    fn add(mut self, rhs: StorageType<T>) -> StorageType<T> {
+        todo!()
+    }
+}
+
+// A += &B
+impl<T: Primitive> AddAssign<&StorageType<T>> for StorageType<T>
+where
+    T: Primitive,
+    ArrayD<T>: for<'a> AddAssign<&'a ArrayD<T>>,
+{
+    fn add_assign(&mut self, rhs: &StorageType<T>) {
+        todo!()
+    }
+}
+
+// A + &B, add(&B) for A
+impl<T: Primitive> ops::Add<&StorageType<T>> for StorageType<T>
+where
+    T: Primitive,
+{
+    type Output = StorageType<T>;
+    fn add(mut self, rhs: &StorageType<T>) -> Self::Output {
+        todo!()
+    }
+}
+
+// Subtraction
+// A - &B
+impl<T: Primitive> Sub<&StorageType<T>> for StorageType<T> {
+    type Output = StorageType<T>;
+
+    fn sub(self, other: &StorageType<T>) -> StorageType<T> {
+        // respect move semantics here (let c = a - b)
+        storage_binary_move_op(self, other, |mut a, b| {
+            a = a - b;
+            StorageType::ArrayData(a)
+        })
+    }
+}
+// &A - B
+// leave unimplented for now, doesn't seem necessary
+// impl<T: Primitive> Sub<StorageType<T>> for &StorageType<T> {
+//     type Output = StorageType<T>;
+
+//     fn sub(self, rhs: StorageType<T>) -> Self::Output {
+//         storage_binary_move_op(rhs, self, |a, b| StorageType::ArrayData(a - b))
+//     }
+// }
+// A - B
+impl<T: Primitive> Sub<StorageType<T>> for StorageType<T> {
+    type Output = StorageType<T>;
+
+    fn sub(self, other: Self) -> StorageType<T> {
+        self - &other
+    }
+}
+
+// &A - &B
+impl<T: Primitive> Sub<&StorageType<T>> for &StorageType<T> {
+    type Output = StorageType<T>;
+
+    fn sub(self, other: &StorageType<T>) -> Self::Output {
+        storage_binary_op(self, other, |a, b| StorageType::ArrayData(a - b))
+    }
+}
+
+
+
+// &A -= &B
+// impl<T> SubAssign<&StorageType<T>> for &mut StorageType<T>
+// where
+//     T: Primitive,
+//     ArrayD<T>: for<'a> SubAssign<&'a ArrayD<T>>,
+// {
+//     fn sub_assign(&mut self, rhs: &StorageType<T>) {
+//         match (self, rhs) {
+//             (StorageType::ArrayData(arr_a), StorageType::ArrayData(arr_b)) => *arr_a -= arr_b,
+//             (StorageType::CudaData(arr_a), StorageType::CudaData(arr_b)) => todo!(),
+//             _ => panic!("Tensors must be on same device"), // TODO return proper result
+//         }
+//         // storage_apply2!(
+//         //     self,
+//         //     other,
+//         //     |a: &mut ArrayD<T>, b: ArrayD<T>| *a -= b,
+//         //     |a: &CudaData<T>, b: &CudaData<T>| todo!()
+//         // )
+//     }
+// }
+
+
+impl<T> SubAssign<&StorageType<T>> for StorageType<T> 
+// where ArrayD<T>: SubAssign<ArrayD<T>>
+where T:Primitive, ArrayD<T>: for<'a> SubAssign<&'a ArrayD<T>>,
+
+{
+    fn sub_assign(&mut self, other: &StorageType<T>) {
+        storage_apply2!(
+            self,
+            other,
+            |a: &mut ArrayD<T>, b: &ArrayD<T>| *a -= b,
+            |a: &CudaData<T>, b: &CudaData<T>| todo!()
+        )
+    }
+}
+
+impl<T> SubAssign<StorageType<T>> for StorageType<T> 
+where T:Primitive, ArrayD<T>: for<'a> SubAssign<&'a ArrayD<T>>,
+{
+    fn sub_assign(&mut self, rhs: StorageType<T>) {
+        *self -= &rhs;
+    }
+}
+
+// Multiplication
+// &A * &B
+impl<T: Primitive> Mul<&StorageType<T>> for &StorageType<T> {
+    type Output = StorageType<T>;
+
+    fn mul(self, other: &StorageType<T>) -> StorageType<T> {
+        storage_binary_op(self, other, |a, b| StorageType::ArrayData(a * b))
+    }
+}
+
+// A * &B
+impl<T: Primitive> Mul<&StorageType<T>> for StorageType<T> {
+    type Output = StorageType<T>;
+
+    fn mul(self, other: &StorageType<T>) -> StorageType<T> {
+        storage_binary_move_op(self, other, |mut a, b| {
+            a = a * b;
+            StorageType::ArrayData(a)
+        })
+    }
+}
+
+impl<T: Primitive> Mul<StorageType<T>> for StorageType<T> {
+    type Output = StorageType<T>;
+
+    fn mul(self, rhs: StorageType<T>) -> Self::Output {
+        // same as above A * &B
+        self * &rhs
+    }
+}
+
+
+// Negation
+impl<T: Primitive> Neg for StorageType<T> {
+    type Output = StorageType<T>;
+
+    fn neg(self) -> StorageType<T> {
+        todo!()
+    }
+}
+
+// Equality comparison
+impl<T: Primitive> PartialEq<StorageType<T>> for StorageType<T> {
+    fn eq(&self, other: &StorageType<T>) -> bool {
+        storage_apply2!(
+            self,
+            other,
+            |a: &ArrayD<T>, b: &ArrayD<T>| a == b,
+            |a: &CudaData<T>, b: &CudaData<T>| todo!()
+        )
+    }
+    fn ne(&self, other: &StorageType<T>) -> bool {
+        storage_apply2!(
+            self,
+            other,
+            |a: &ArrayD<T>, b: &ArrayD<T>| a != b,
+            |a: &CudaData<T>, b: &CudaData<T>| todo!()
+        )
+    }
+}
+impl<T: Primitive> PartialEq<ArrayD<T>> for &StorageType<T> {
+    fn eq(&self, other: &ArrayD<T>) -> bool {
+        if let StorageType::ArrayData(arr) = &self {
+            return arr == other;
+        } else {
+            todo!()
+        }
+    }
+    fn ne(&self, other: &ArrayD<T>) -> bool {
+        if let StorageType::ArrayData(arr) = &self {
+            return arr != other;
+        } else {
+            todo!()
+        }
+    }
+}
+
+impl<T: Primitive> PartialEq<ArrayD<T>> for StorageType<T> {
+    fn eq(&self, other: &ArrayD<T>) -> bool {
+        return &self == other;
+    }
+    fn ne(&self, other: &ArrayD<T>) -> bool {
+        return &self != other;
+    }
+}
+
+//** Scalar operators **/
+
+impl<T> MulAssign<T> for StorageType<T>
+where
+    T: Primitive + ScalarOperand + MulAssign{
+    fn mul_assign(&mut self, scalar: T) {
+        match self {
+            StorageType::ArrayData(arr_a) => *arr_a *= scalar,
+            _ => todo!(),
+        }        
+    }
+}
+
+impl<T: Primitive> Div<T> for &StorageType<T>
+where
+    T: Primitive + ScalarOperand,
+{
+    type Output = StorageType<T>;
+    fn div(self, scalar: T) -> Self::Output {
+        // return new storage
+        storage_apply!(self,
+            |a: &ArrayD<T>| StorageType::ArrayData(a / scalar),
+            |a: &CudaData<T>| todo!()
+        )
+    }
+}
+
+impl<T: Primitive> Div<T> for StorageType<T>
+where
+    T: Primitive + ScalarOperand,
+{
+    type Output = StorageType<T>;
+    fn div(self, scalar: T) -> Self::Output {
+        &self / scalar
+    }
+}
+
+impl<T: Primitive> DivAssign<T> for StorageType<T>
+where
+    T: Primitive + ScalarOperand + DivAssign,
+{
+    fn div_assign(&mut self, scalar: T) {
+        match self {
+            StorageType::ArrayData(arr_a) => *arr_a /= scalar,
+            _ => todo!(),
+        }        
+    }
+}
+
+// *Scalar* - Tensor
+
+impl Sub<&StorageType<f32>> for f32 {
+    type Output = StorageType<f32>;
+    fn sub(self, rhs: &StorageType<f32>) -> Self::Output {
+        storage_apply!(rhs,
+            |a: &ArrayD<f32>| {
+                // transform scalar into array and do sub
+                let scalar_arr = ndarray::array![self].into_dyn();
+                StorageType::ArrayData(scalar_arr - a)
+            },
+            |a: &CudaData<f32>| todo!()
+        )
+    }
+}
+
+impl Sub<StorageType<f32>> for f32 {
+    type Output = StorageType<f32>;
+    fn sub(self, rhs: StorageType<f32>) -> Self::Output {
+        self - &rhs
+    }
+}
+
+
+// Scalar * A, will create a new storage
+impl<T: Primitive> Mul<T> for &StorageType<T>
+where
+    T: Primitive + ScalarOperand,
+{
+    type Output = StorageType<T>;
+    fn mul(self, scalar: T) -> Self::Output {
+        storage_apply!(self,
+            |a: &ArrayD<T>| StorageType::ArrayData(a * scalar),
+            |a: &CudaData<T>| todo!()
+        )
+
+    }
+}
+
+impl<T: Primitive> Mul<T> for StorageType<T>
+where
+    T: Primitive + ScalarOperand,
+{
+    type Output = StorageType<T>;
+    fn mul(self, scalar: T) -> Self::Output {
+        &self * scalar
+    }
+}
+
+
+/** Indexing **/
+// impl<T: Primitive> StorageType<T> {
+//     fn compute_flat_index(&self, index: &[usize]) -> usize {
+//         // Compute a flat index from the multi-dimensional index.
+//         // This usually involves multiplying the index components by the size of the corresponding dimensions.
+//         // Here, we assume row-major order for simplicity.
+//         let mut flat_index = 0;
+//         for (i, &dim_size) in self.dims.iter().enumerate() {
+//             flat_index = flat_index * dim_size + index[i];
+//         }
+//         flat_index
+//     }
+// }
+
+impl<T: Primitive> Index<&[usize]> for StorageType<T> {
+    type Output = T;
+
+    fn index(&self, index: &[usize]) -> &Self::Output {
+        if let StorageType::ArrayData(arr) = &self {
+            return &arr[index];
+        } else {
+            todo!()
+        }
+    }
+}
+
+impl<T: Primitive> IndexMut<&[usize]> for StorageType<T> {
+    fn index_mut(&mut self, index: &[usize]) -> &mut Self::Output {
+        if let StorageType::ArrayData(arr) = self {
+            return arr.index_mut(index);
+        } else {
+            todo!()
+        }
+    }
+}
+
+// index with fixed-size arrays
+macro_rules! add_indexing {
+    ($dims:expr) => {
+        impl<T: Primitive> Index<[usize; $dims]> for StorageType<T> {
+            type Output = T;
+
+            fn index(&self, index: [usize; $dims]) -> &Self::Output {
+                if let StorageType::ArrayData(arr) = &self {
+                    return &arr[index];
+                } else {
+                    todo!()
+                }
+            }
+        }
+
+        impl<T: Primitive> IndexMut<[usize; $dims]> for StorageType<T> {
+            fn index_mut(&mut self, index: [usize; $dims]) -> &mut Self::Output {
+                if let StorageType::ArrayData(arr) = self {
+                    return arr.index_mut(index);
+                } else {
+                    todo!()
+                }
+            }
+        }
+    };
+}
+
+add_indexing!(1);
+add_indexing!(2);
+add_indexing!(3);
+add_indexing!(4);
+add_indexing!(5);
+
+/*************** CUDA ops ****************/
+// &A + &B
+impl<T: Primitive> ops::Add<&CudaData<T>> for &CudaData<T>
+where
+    T: Primitive,
+{
+    type Output = CudaData<T>;
+
+    fn add(self, rhs: &CudaData<T>) -> Self::Output {
+        todo!()
+    }
+}
+
+// A + B
+impl<T: Primitive> ops::Add<CudaData<T>> for CudaData<T>
+where
+    T: Primitive,
+{
+    type Output = CudaData<T>;
+    fn add(mut self, rhs: CudaData<T>) -> CudaData<T> {
+        todo!()
+    }
+}
+
+// A += &B
+impl<T: Primitive> AddAssign<&CudaData<T>> for CudaData<T>
+where
+    T: Primitive,
+    ArrayD<T>: for<'a> AddAssign<&'a ArrayD<T>>,
+{
+    fn add_assign(&mut self, rhs: &CudaData<T>) {
+        todo!()
+    }
+}
+
+// A + &B, add(&B) for A
+impl<T: Primitive> ops::Add<&CudaData<T>> for CudaData<T>
+where
+    T: Primitive,
+{
+    type Output = CudaData<T>;
+    fn add(mut self, rhs: &CudaData<T>) -> Self::Output {
+        todo!()
+    }
+}

--- a/src/tensor/tensor.rs
+++ b/src/tensor/tensor.rs
@@ -84,9 +84,6 @@ pub enum StorageType<T> {
 }
 
 impl<T: Primitive> StorageType<T> {
-    pub fn t(&self) -> StorageType<T> {
-        todo!()
-    }
     pub fn ndim(&self) -> usize {
         storage_apply!(&self, |x: &ArrayD<T>| x.ndim(), |x: &CudaData<T>| todo!())
     }
@@ -121,6 +118,10 @@ impl<T: Primitive> StorageType<T> {
     }
     pub fn len(&self) -> usize {
         storage_apply!(&self, |x: &ArrayD<T>| x.len(), |x: &CudaData<T>| todo!())
+    }
+
+    pub fn t_clone(&self) -> ArrayD<T> {
+        storage_apply!(&self, |x: &ArrayD<T>| x.t().to_owned(), |x: &CudaData<T>| todo!())
     }
 
     // ops
@@ -362,7 +363,7 @@ where
     }
     pub fn t_clone(&self) -> Self {
         // TODO too many copies
-        Tensor::from(self.data().t().to_owned())
+        Tensor::from(self.data().t_clone())
     }
     pub fn ndim(&self) -> usize {
         self.data().ndim()

--- a/src/tensor/tensor.rs
+++ b/src/tensor/tensor.rs
@@ -1,24 +1,18 @@
 use crate::autograd::autograd::{backward_algo, Node};
-use crate::operators::operators::shared_ptr_new;
-use ndarray::iter::{Iter, IterMut};
+use crate::utils::shared_ptr_new;
 use ndarray::linalg::Dot;
-use ndarray::{array, Array, ArrayD, ArrayView, ArrayViewMut, Axis, Dimension, Ix2, IxDyn};
+use ndarray::{array, Array, ArrayD, Axis, Dimension, Ix2, IxDyn};
 use std::cell::{Ref, RefCell, RefMut};
 use std::convert::From;
 use std::ops::AddAssign;
 use std::rc::Rc;
 
 extern crate num_traits;
-
+// TODO move tensor to mod.rs?
 use super::init::{kaiming_uniform, uniform};
-use super::storage;
-use num_traits::{cast::FromPrimitive, Num, NumCast};
-pub trait Primitive: Copy + NumCast + Num + PartialOrd<Self> + Clone + FromPrimitive {}
-impl Primitive for u8 {}
-impl Primitive for f32 {}
-impl Primitive for f64 {}
-impl Primitive for i32 {}
-impl Primitive for i64 {}
+use super::Primitive;
+use super::storage::StorageType;
+use crate::{storage_apply, storage_apply2};
 
 // trait WellBehavedArray<T, D> where T: Float+FromPrimitive, D: Dimension, Array<T, D>: Dot<Array<T, D>, Output = Array<T, D>> {}
 // trait WellBehavedArray: PartialOrd + Display {}
@@ -26,201 +20,8 @@ impl Primitive for i64 {}
 
 // TODO for view+owned, though not elegant https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=4095c89a23a2339a1e7afe3813c9acc3
 type SharedPtr<T> = Rc<RefCell<T>>;
-type SharedArray<T> = SharedPtr<Array<T, IxDyn>>;
 
-fn deep_copy_shared_array<T: Clone>(t: &SharedArray<T>) -> SharedArray<T> {
-    shared_ptr_new(t.borrow().to_owned())
-}
 
-fn add_shared_array_inplace<T: Primitive>(a: &mut SharedArray<T>, b: &SharedArray<T>)
-where
-    ArrayD<T>: for<'a> AddAssign<&'a ArrayD<T>>,
-{
-    let mut a_t = a.borrow_mut();
-    let b_t = &b.borrow();
-    *a_t += *&b_t;
-}
-
-#[derive(Clone, Debug)]
-pub struct CudaData<T> {
-    pub ptr: *mut T,
-}
-
-impl<T> Drop for CudaData<T> {
-    fn drop(&mut self) {
-        // deallocate_cuda_memory(self.ptr);  // Replace with your actual deallocation function
-    }
-}
-
-#[macro_export]
-macro_rules! storage_apply {
-    ($value:expr, $func_array:expr, $func_cuda:expr) => {
-        match $value {
-            StorageType::ArrayData(arr) => $func_array(arr),
-            StorageType::CudaData(arr) => $func_cuda(arr),
-        }
-    };
-}
-
-#[macro_export]
-macro_rules! storage_apply2 {
-    ($value1:expr, $value2:expr, $func_array:expr, $func_cuda:expr) => {
-        match ($value1, $value2) {
-            (StorageType::ArrayData(arr_a), StorageType::ArrayData(arr_b)) => {
-                $func_array(arr_a, arr_b)
-            }
-            (StorageType::CudaData(cuda_a), StorageType::CudaData(cuda_b)) => {
-                $func_cuda(cuda_a, cuda_b)
-            }
-            _ => panic!("Tensors must be on same device"),
-        }
-    };
-}
-// TODO move into own file
-#[derive(Clone, Debug)]
-pub enum StorageType<T> {
-    ArrayData(Array<T, IxDyn>), // CPU
-    CudaData(CudaData<T>),      // CUDA
-}
-
-impl<T: Primitive> StorageType<T> {
-    pub fn ndim(&self) -> usize {
-        storage_apply!(&self, |x: &ArrayD<T>| x.ndim(), |x: &CudaData<T>| todo!())
-    }
-    pub fn shape(&self) -> Vec<usize> {
-        storage_apply!(&self, |x: &ArrayD<T>| x.shape().to_vec(), |x: &CudaData<
-            T,
-        >| todo!())
-    }
-    pub fn raw_dim(&self) -> Vec<usize> {
-        // on raw_dim/shape difference https://docs.rs/ndarray/latest/ndarray/struct.ArrayBase.html#method.shape
-        // all our arrays have dyn shape anyway
-        self.shape()
-    }
-    pub fn is_contiguous(&self) -> bool {
-        storage_apply!(
-            &self,
-            |x: &ArrayD<T>| x.is_standard_layout(),
-            |x: &CudaData<T>| true
-        )
-    }
-    pub fn is_empty(&self) -> bool {
-        storage_apply!(
-            &self,
-            |x: &ArrayD<T>| self.len() == 0,
-            |x: &CudaData<T>| self.len() == 0
-        )
-    }
-    pub fn fill(&mut self, el: T) {
-        storage_apply!(self, |x: &mut ArrayD<T>| x.fill(el), |x: &mut CudaData<
-            T,
-        >| todo!())
-    }
-    pub fn len(&self) -> usize {
-        storage_apply!(&self, |x: &ArrayD<T>| x.len(), |x: &CudaData<T>| todo!())
-    }
-
-    pub fn t_clone(&self) -> ArrayD<T> {
-        storage_apply!(&self, |x: &ArrayD<T>| x.t().to_owned(), |x: &CudaData<
-            T,
-        >| todo!())
-    }
-
-    // ops
-    pub fn sum(&self) -> T {
-        storage_apply!(&self, |x: &ArrayD<T>| x.sum(), |x: &CudaData<T>| todo!())
-    }
-    pub fn sum_axis(&self, a: Axis) -> ArrayD<T> {
-        storage_apply!(
-            &self,
-            |x: &ArrayD<T>| x.sum_axis(a),
-            |x: &CudaData<T>| todo!()
-        )
-    }
-    pub fn mean(&self) -> T {
-        storage_apply!(&self, |x: &ArrayD<T>| x.mean().unwrap(), |x: &CudaData<
-            T,
-        >| todo!())
-    }
-    pub fn mean_axis(&self, a: Axis) -> ArrayD<T> {
-        storage_apply!(
-            &self,
-            |x: &ArrayD<T>| x.mean_axis(a).unwrap(),
-            |x: &CudaData<T>| todo!()
-        )
-    }
-
-    pub fn broadcast(&self, a: IxDyn) -> ArrayD<T> {
-        storage_apply!(
-            &self,
-            |x: &ArrayD<T>| x.broadcast(a).unwrap().to_owned(),
-            |x: &CudaData<T>| todo!()
-        )
-    }
-
-    // TODO dont want to implement these for cuda tbh, ndarray dispatch should be handled by caller, hence they just return ndarrays
-    pub fn mapv(&self, f: impl Fn(T) -> T) -> ArrayD<T> {
-        storage_apply!(&self, |x: &ArrayD<T>| x.mapv(f), |x: &CudaData<T>| todo!())
-    }
-
-    pub fn mapv_inplace(&mut self, f: impl Fn(T) -> T) {
-        storage_apply!(
-            self,
-            |x: &mut ArrayD<T>| x.mapv_inplace(f),
-            |x: &mut CudaData<T>| todo!()
-        )
-    }
-
-    pub fn map(&self, f: impl Fn(&T) -> T) -> ArrayD<T> {
-        storage_apply!(&self, |x: &ArrayD<T>| x.map(f), |x: &CudaData<T>| todo!())
-    }
-
-    pub fn view(&self) -> ArrayView<T, IxDyn> {
-        if let StorageType::ArrayData(arr) = self {
-            arr.view()
-        } else {
-            panic!("Not Implemented for CudaData")
-        }
-    }
-
-    pub fn view_mut(&mut self) -> ArrayViewMut<T, IxDyn> {
-        if let StorageType::ArrayData(arr) = self {
-            arr.view_mut()
-        } else {
-            panic!("Not Implemented for CudaData")
-        }
-    }
-
-    pub fn iter(&self) -> Iter<T, IxDyn> {
-        if let StorageType::ArrayData(arr) = self {
-            arr.iter()
-        } else {
-            panic!("Not Implemented for CudaData")
-        }
-    }
-
-    pub fn iter_mut(&mut self) -> IterMut<T, IxDyn> {
-        if let StorageType::ArrayData(arr) = self {
-            arr.iter_mut()
-        } else {
-            panic!("Not Implemented for CudaData")
-        }
-    }
-
-    pub fn into_raw_vec(&self) -> Vec<T> {
-        if let StorageType::ArrayData(arr) = self {
-            arr.clone().into_raw_vec()
-        } else {
-            panic!("Not Implemented for CudaData")
-        }
-    }
-}
-
-#[derive(Clone)]
-pub enum Device {
-    CPU,
-    CUDA,
-}
 
 #[derive(Clone)]
 // clone is now inexpensive as we're just referencing the data, not owning it

--- a/src/tensor/tensor.rs
+++ b/src/tensor/tensor.rs
@@ -52,6 +52,7 @@ impl<T> Drop for CudaData<T> {
     }
 }
 
+#[macro_export]
 macro_rules! storage_apply {
     ($value:expr, $func_array:expr, $func_cuda:expr) => {
         match $value {
@@ -345,7 +346,7 @@ where
         // let mut t = Tensor::from(self.data().mapv(|elem| A::from(elem).unwrap()));
         let mut t = Tensor::from(storage_apply!(
             &*self.data(),
-            |x: &ArrayD<i64>| x.mapv(|elem| A::from(elem).unwrap()),
+            |x: &ArrayD<T>| x.mapv(|elem| A::from(elem).unwrap()),
             |x| todo!()
         ));
         t.requires_grad = self.requires_grad;

--- a/src/tensor/tensor.rs
+++ b/src/tensor/tensor.rs
@@ -10,8 +10,8 @@ use std::rc::Rc;
 extern crate num_traits;
 // TODO move tensor to mod.rs?
 use super::init::{kaiming_uniform, uniform};
-use super::Primitive;
 use super::storage::StorageType;
+use super::Primitive;
 use crate::{storage_apply, storage_apply2};
 
 // trait WellBehavedArray<T, D> where T: Float+FromPrimitive, D: Dimension, Array<T, D>: Dot<Array<T, D>, Output = Array<T, D>> {}
@@ -20,8 +20,6 @@ use crate::{storage_apply, storage_apply2};
 
 // TODO for view+owned, though not elegant https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=4095c89a23a2339a1e7afe3813c9acc3
 type SharedPtr<T> = Rc<RefCell<T>>;
-
-
 
 #[derive(Clone)]
 // clone is now inexpensive as we're just referencing the data, not owning it
@@ -384,7 +382,7 @@ where
                 // will panic if the array is *NOT* contiguous
                 let reshaped_array = arr.into_shape(shape).unwrap();
                 let _ = self.data.replace(StorageType::ArrayData(reshaped_array));
-            },
+            }
             StorageType::CudaData(_) => todo!(),
         }
 

--- a/src/tensor/tensor_arithmetic.rs
+++ b/src/tensor/tensor_arithmetic.rs
@@ -5,7 +5,9 @@
 ** level that implements the dispatching down to the most concrete type (as of now).
 */
 
-use super::tensor::{Primitive, StorageType, Tensor};
+use crate::tensor::Primitive;
+use super::tensor::Tensor;
+use super::storage::StorageType;
 use super::utils::{tensor_op, tensor_op_mut};
 use ndarray::{ArrayD, IxDyn, ScalarOperand};
 use num_traits::Signed;

--- a/src/tensor/utils.rs
+++ b/src/tensor/utils.rs
@@ -1,0 +1,55 @@
+use super::tensor::{Primitive, StorageType, Tensor};
+use ndarray::{ArrayD, IxDyn, ScalarOperand};
+
+// helper functions for dispatching based on StorageType
+pub fn tensor_op<T: Primitive>(
+    lhs: &Tensor<T>,
+    rhs: &Tensor<T>,
+    cpu_f: fn(&ArrayD<T>, &ArrayD<T>) -> Tensor<T>,
+) -> Tensor<T> {
+    let storage = lhs.data();
+    let rstorage = rhs.data();
+    match (&*storage, &*rstorage) {
+        (StorageType::ArrayData(arr_a), StorageType::ArrayData(arr_b)) => cpu_f(arr_a, arr_b),
+        (StorageType::CudaData(arr_a), StorageType::CudaData(arr_b)) => todo!(),
+        _ => panic!("Tensors must be on same device"), // TODO return proper result
+    }
+}
+
+pub fn tensor_op_mut<T: Primitive>(
+    lhs: &mut Tensor<T>,
+    rhs: &Tensor<T>,
+    cpu_f: impl Fn(&mut ArrayD<T>, &ArrayD<T>),
+) {
+    let mut storage = lhs.data_mut();
+    let rstorage = rhs.data();
+    match (&mut *storage, &*rstorage) {
+        (StorageType::ArrayData(arr_a), StorageType::ArrayData(arr_b)) => cpu_f(arr_a, arr_b),
+        (StorageType::CudaData(arr_a), StorageType::CudaData(arr_b)) => todo!(),
+        _ => panic!("Tensors must be on same device"),
+    }
+}
+
+pub fn storage_binary_op<T: Primitive>(
+    lhs: &StorageType<T>,
+    rhs: &StorageType<T>,
+    cpu_f: fn(&ArrayD<T>, &ArrayD<T>) -> StorageType<T>,
+) -> StorageType<T> {
+    match (lhs, rhs) {
+        (StorageType::ArrayData(arr_a), StorageType::ArrayData(arr_b)) => cpu_f(arr_a, arr_b),
+        (StorageType::CudaData(arr_a), StorageType::CudaData(arr_b)) => todo!(),
+        _ => panic!("Tensors must be on same device"), // TODO return proper result
+    }
+}
+
+pub fn storage_binary_op_mut<T: Primitive>(
+    lhs: &mut StorageType<T>,
+    rhs: &StorageType<T>,
+    cpu_f: impl Fn(&mut ArrayD<T>, &ArrayD<T>) -> StorageType<T>,
+) -> StorageType<T> {
+    match (lhs, rhs) {
+        (StorageType::ArrayData(arr_a), StorageType::ArrayData(arr_b)) => cpu_f(arr_a, arr_b),
+        (StorageType::CudaData(arr_a), StorageType::CudaData(arr_b)) => todo!(),
+        _ => panic!("Tensors must be on same device"), // TODO return proper result
+    }
+}

--- a/src/tensor/utils.rs
+++ b/src/tensor/utils.rs
@@ -1,5 +1,16 @@
-use super::tensor::{Primitive, StorageType, Tensor};
+use super::Primitive;
+use super::tensor::Tensor;
+use super::storage::StorageType;
+use crate::utils::SharedPtr;
 use ndarray::{ArrayD, IxDyn, ScalarOperand};
+use crate::utils::shared_ptr_new;
+use ndarray::Array;
+
+pub type SharedArray<T> = SharedPtr<Array<T, IxDyn>>;
+
+fn deep_copy_shared_array<T: Clone>(t: &SharedArray<T>) -> SharedArray<T> {
+    shared_ptr_new(t.borrow().to_owned())
+}
 
 // helper functions for dispatching based on StorageType
 pub fn tensor_op<T: Primitive>(

--- a/src/tensor/utils.rs
+++ b/src/tensor/utils.rs
@@ -53,3 +53,12 @@ pub fn storage_binary_op_mut<T: Primitive>(
         _ => panic!("Tensors must be on same device"), // TODO return proper result
     }
 }
+
+
+pub fn storage_binary_move_op<T:Primitive>(a: StorageType<T>, b: &StorageType<T>, cpu_f: impl Fn(ArrayD<T>, &ArrayD<T>)->StorageType<T>)-> StorageType<T> {
+    match (a, b) {
+        (StorageType::ArrayData(mut arr_a), StorageType::ArrayData(arr_b)) => cpu_f(arr_a, arr_b),
+        (StorageType::CudaData(arr_a), StorageType::CudaData(arr_b)) => todo!(),
+        _ => panic!("Tensors must be on same device"), // TODO return proper result
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,1 +1,9 @@
 pub mod utils;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+pub type SharedPtr<T> = Rc<RefCell<T>>;
+
+pub fn shared_ptr_new<T>(x: T) -> SharedPtr<T> {
+    Rc::new(RefCell::new(x))
+}

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -3,7 +3,8 @@ pub mod export {
     use crate::autograd::autograd::Node;
     use crate::nn::model::NN;
     use crate::operators::operators::Operators;
-    use crate::tensor::tensor::{Powi, Primitive, Tensor};
+    use crate::tensor::Primitive;
+    use crate::tensor::tensor::{Powi, Tensor};
 
     const TORCH_IMPORT_TEMPLATE: &str = "import torch\nimport torch.nn as nn\nimport torch.nn.functional as F\n\n";
 


### PR DESCRIPTION
This PR introduces the abstraction needed to work with both CPU(ndarray) and GPU(cuda) backed tensors, StorageType.
It required refactoring most operations, as the dispatching chain is now something like:
```
Tensor->StorageType-> ndarray CPU
                                  \-> cuda GPU
```
Code behavior *should* be unchanged for cpu tensors.

Mind that this PR does NOT (yet) introduce support for cuda operations, but it prepares the code structure needed to support it (all cuda ops are currently todo!()).
